### PR TITLE
ignore venv folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 ignored
 
 .venv
+venv

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__
 ignored
+
+.venv


### PR DESCRIPTION
add typical .venv and venv folders to .gitignore file, to allow create virtual python environment.