### PR TITLE
Add smart matting material support

### DIFF
--- a/pyJianYingDraft/__init__.py
+++ b/pyJianYingDraft/__init__.py
@@ -1,7 +1,7 @@
 import warnings
 import sys
 
-from .local_materials import CropSettings, VideoMaterial, AudioMaterial
+from .local_materials import CropSettings, VideoMaterial, VideoMaterialMatting, AudioMaterial
 from .keyframe import KeyframeProperty
 
 from .time_util import Timerange

--- a/pyJianYingDraft/local_materials.py
+++ b/pyJianYingDraft/local_materials.py
@@ -2,7 +2,7 @@ import os
 import uuid
 import pymediainfo
 
-from typing import Optional, Literal
+from typing import Optional, Literal, List
 from typing import Dict, Any
 
 class CropSettings:
@@ -43,6 +43,40 @@ class CropSettings:
             "lower_right_y": self.lower_right_y
         }
 
+class VideoMaterialMatting:
+    """视频素材的智能抠像设置"""
+
+    flag: int
+    """抠像标记, 3 表示智能人像抠像"""
+    path: str
+    """剪映生成的抠像缓存路径, 新建素材时通常为空"""
+    has_use_quick_brush: bool
+    has_use_quick_eraser: bool
+    interactive_time: List[Any]
+    strokes: List[Any]
+
+    def __init__(self, flag: int = 3, path: str = "",
+                 has_use_quick_brush: bool = False, has_use_quick_eraser: bool = False,
+                 interactive_time: Optional[List[Any]] = None, strokes: Optional[List[Any]] = None):
+        self.flag = flag
+        self.path = path
+        self.has_use_quick_brush = has_use_quick_brush
+        self.has_use_quick_eraser = has_use_quick_eraser
+        self.interactive_time = interactive_time if interactive_time is not None else []
+        self.strokes = strokes if strokes is not None else []
+
+    def export_json(self) -> Dict[str, Any]:
+        matting_json = {
+            "flag": self.flag,
+            "has_use_quick_brush": self.has_use_quick_brush,
+            "has_use_quick_eraser": self.has_use_quick_eraser,
+            "interactiveTime": self.interactive_time,
+            "strokes": self.strokes
+        }
+        if self.path:
+            matting_json["path"] = self.path
+        return matting_json
+
 class VideoMaterial:
     """本地视频素材（视频或图片）, 一份素材可以在多个片段中使用"""
 
@@ -64,6 +98,8 @@ class VideoMaterial:
     """素材裁剪设置"""
     material_type: Literal["video", "photo"]
     """素材类型: 视频或图片"""
+    matting: Optional[VideoMaterialMatting]
+    """智能抠像设置, 为空时不启用"""
 
     def __init__(self, path: str, material_name: Optional[str] = None, crop_settings: CropSettings = CropSettings()):
         """从指定位置加载视频（或图片）素材
@@ -87,6 +123,7 @@ class VideoMaterial:
         self.path = path
         self.crop_settings = crop_settings
         self.local_material_id = ""
+        self.matting = None
 
         if not pymediainfo.MediaInfo.can_parse():
             raise ValueError(f"不支持的视频素材类型 '{postfix}'")
@@ -134,6 +171,8 @@ class VideoMaterial:
             "type": self.material_type,
             "width": self.width
         }
+        if self.matting is not None:
+            video_material_json["matting"] = self.matting.export_json()
         return video_material_json
 
 class AudioMaterial:

--- a/pyJianYingDraft/local_materials.py
+++ b/pyJianYingDraft/local_materials.py
@@ -91,13 +91,21 @@ class VideoMaterialMatting:
 
     def __init__(self, flag: int = 3, path: str = "",
                  has_use_quick_brush: bool = False, has_use_quick_eraser: bool = False,
-                 interactive_time: Optional[List[Any]] = None, strokes: Optional[List[Any]] = None):
+                 interactive_time: Optional[List[Any]] = None, strokes: Optional[List[Any]] = None,
+                 *, reuse_cache: bool = False):
+        interactive_time = interactive_time if interactive_time is not None else []
+        strokes = strokes if strokes is not None else []
+        if not reuse_cache and (
+            path or has_use_quick_brush or has_use_quick_eraser or interactive_time or strokes
+        ):
+            raise ValueError("matting cache fields require reuse_cache=True")
+
         self.flag = flag
         self.path = path
         self.has_use_quick_brush = has_use_quick_brush
         self.has_use_quick_eraser = has_use_quick_eraser
-        self.interactive_time = interactive_time if interactive_time is not None else []
-        self.strokes = strokes if strokes is not None else []
+        self.interactive_time = interactive_time
+        self.strokes = strokes
 
     def export_json(self) -> Dict[str, Any]:
         matting_json = {

--- a/pyJianYingDraft/video_segment.py
+++ b/pyJianYingDraft/video_segment.py
@@ -11,7 +11,7 @@ from typing import Dict, List, Tuple, Any
 
 from .time_util import tim, Timerange
 from .segment import VisualSegment, ClipSettings, AudioFade
-from .local_materials import VideoMaterial
+from .local_materials import VideoMaterial, VideoMaterialMatting
 from .animation import SegmentAnimations, VideoAnimation
 
 from .metadata import EffectMeta, EffectParamInstance
@@ -497,6 +497,16 @@ class VideoSegment(VisualSegment):
         self.mix_modes.append(mix_mode_inst)
         self.extra_material_refs.append(mix_mode_inst.global_id)
 
+        return self
+
+    def add_smart_matting(self, *, path: str = "") -> "VideoSegment":
+        """为视频素材添加智能人像抠像标记
+
+        Args:
+            path (`str`, optional): 剪映生成的抠像缓存路径. 默认不写入缓存路径,
+                由剪映在打开或导出草稿时生成.
+        """
+        self.material_instance.matting = VideoMaterialMatting(path=path)
         return self
 
     def add_mask(self, mask_type: MaskType, *, center_x: float = 0.0, center_y: float = 0.0, size: float = 0.5,

--- a/pyJianYingDraft/video_segment.py
+++ b/pyJianYingDraft/video_segment.py
@@ -499,14 +499,19 @@ class VideoSegment(VisualSegment):
 
         return self
 
-    def add_smart_matting(self, *, path: str = "") -> "VideoSegment":
+    def add_smart_matting(self, *, path: str = "", reuse_cache: bool = False) -> "VideoSegment":
         """为视频素材添加智能人像抠像标记
 
         Args:
             path (`str`, optional): 剪映生成的抠像缓存路径. 默认不写入缓存路径,
                 由剪映在打开或导出草稿时生成.
+            reuse_cache (`bool`, optional): 是否显式复用已生成的剪映抠像缓存.
+                默认为否, 以避免不同素材之间误用旧的人像轮廓.
         """
-        self.material_instance.matting = VideoMaterialMatting(path=path)
+        self.material_instance.matting = VideoMaterialMatting(
+            path=path,
+            reuse_cache=reuse_cache,
+        )
         return self
 
     def add_mask(self, mask_type: MaskType, *, center_x: float = 0.0, center_y: float = 0.0, size: float = 0.5,

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,18 @@
+from pathlib import Path
+
 from setuptools import setup, find_packages
+
+
+readme_path = Path("pypi_readme.md")
+if not readme_path.exists():
+    readme_path = Path("README.md")
 
 setup(
     name="pyjianyingdraft",
     version="0.2.6",
     author="gary318",
     description="轻量、灵活、易上手的Python剪映草稿生成及导出工具，构建全自动化视频剪辑/混剪流水线",
-    long_description=open("pypi_readme.md", "r", encoding="utf-8").read(),
+    long_description=readme_path.read_text(encoding="utf-8"),
     long_description_content_type="text/markdown",
     url="https://github.com/GuanYixuan/pyJianYingDraft",
     packages=find_packages(exclude=["tools", "tools.*", "ignored", "ignored.*"]),

--- a/tests/test_smart_matting_cache.py
+++ b/tests/test_smart_matting_cache.py
@@ -1,0 +1,71 @@
+from types import SimpleNamespace
+
+import pytest
+import pyJianYingDraft as draft
+
+
+def test_smart_matting_cache_requires_explicit_reuse() -> None:
+    with pytest.raises(ValueError, match="reuse_cache=True"):
+        draft.VideoMaterialMatting(path="##_draftpath_placeholder_##/matting/cache")
+
+    with pytest.raises(ValueError, match="reuse_cache=True"):
+        draft.VideoMaterialMatting(
+            has_use_quick_brush=True,
+            interactive_time=[100],
+            strokes=[{"x": 1}],
+        )
+
+
+def test_smart_matting_cache_can_be_reused_explicitly() -> None:
+    matting = draft.VideoMaterialMatting(
+        path="##_draftpath_placeholder_##/matting/cache",
+        has_use_quick_brush=True,
+        has_use_quick_eraser=True,
+        interactive_time=[100],
+        strokes=[{"x": 1}],
+        reuse_cache=True,
+    )
+
+    assert matting.export_json() == {
+        "flag": 3,
+        "has_use_quick_brush": True,
+        "has_use_quick_eraser": True,
+        "interactiveTime": [100],
+        "path": "##_draftpath_placeholder_##/matting/cache",
+        "strokes": [{"x": 1}],
+    }
+
+
+def test_add_smart_matting_defaults_to_fresh_cache() -> None:
+    segment = draft.VideoSegment.__new__(draft.VideoSegment)
+    segment.material_instance = SimpleNamespace(matting=None)
+
+    with pytest.raises(ValueError, match="reuse_cache=True"):
+        segment.add_smart_matting(
+            path="##_draftpath_placeholder_##/matting/cache",
+        )
+
+    segment.add_smart_matting()
+
+    assert segment.material_instance.matting.export_json() == {
+        "flag": 3,
+        "has_use_quick_brush": False,
+        "has_use_quick_eraser": False,
+        "interactiveTime": [],
+        "strokes": [],
+    }
+
+
+def test_add_smart_matting_can_reuse_cache_explicitly() -> None:
+    segment = draft.VideoSegment.__new__(draft.VideoSegment)
+    segment.material_instance = SimpleNamespace(matting=None)
+
+    segment.add_smart_matting(
+        path="##_draftpath_placeholder_##/matting/cache",
+        reuse_cache=True,
+    )
+
+    assert (
+        segment.material_instance.matting.export_json()["path"]
+        == "##_draftpath_placeholder_##/matting/cache"
+    )


### PR DESCRIPTION
## Summary

Adds native smart portrait matting support to pyJianYingDraft video materials.

- adds `VideoMaterialMatting` for serializing Jianying's `materials.videos[].matting` node
- lets `VideoMaterial.export_json()` include `matting` only when configured
- adds chainable `VideoSegment.add_smart_matting()` for marking a segment's copied material instance
- exports `VideoMaterialMatting` from the package root

## Why

Jianying drafts created after enabling smart portrait matting store the setting on the video material as a `matting` object. Supporting that node in the library lets callers generate drafts that ask Jianying to perform smart matting during open/export, without UI automation.

## Validation

- `python -m compileall pyJianYingDraft`
- self-contained import/export smoke script using `uv run --with pymediainfo --with imageio --with 'uiautomation>=2; sys_platform == "win32"' python -`
- `git diff --check`
