### PR TITLE
Add native smart matting support

### DIFF
--- a/pyJianYingDraft/__init__.py
+++ b/pyJianYingDraft/__init__.py
@@ -1,7 +1,7 @@
 import warnings
 import sys
 
-from .local_materials import CropSettings, VideoMaterial, AudioMaterial
+from .local_materials import CropSettings, VideoMaterial, VideoMaterialMatting, AudioMaterial
 from .keyframe import KeyframeProperty
 
 from .time_util import Timerange

--- a/pyJianYingDraft/__init__.py
+++ b/pyJianYingDraft/__init__.py
@@ -1,7 +1,7 @@
 import warnings
 import sys
 
-from .local_materials import CropSettings, VideoMaterial, VideoMaterialMatting, AudioMaterial
+from .local_materials import CropSettings, VideoMaterial, VideoMaterialMatting, CombinationMaterial, AudioMaterial
 from .keyframe import KeyframeProperty
 
 from .time_util import Timerange
@@ -207,6 +207,8 @@ __all__ = [
     "VideoCharacterEffectType",
     "CropSettings",
     "VideoMaterial",
+    "VideoMaterialMatting",
+    "CombinationMaterial",
     "AudioMaterial",
     "KeyframeProperty",
     "Timerange",

--- a/pyJianYingDraft/draft_folder.py
+++ b/pyJianYingDraft/draft_folder.py
@@ -62,7 +62,9 @@ class DraftFolder:
 
     def create_draft(self, draft_name: str, width: int, height: int, fps: int = 30, *,
                      maintrack_adsorb: bool = True,
-                     allow_replace: bool = False) -> ScriptFile:
+                     allow_replace: bool = False,
+                     enable_free_index_mode: bool = False,
+                     enable_render_index_track_mode: bool = False) -> ScriptFile:
         """创建一个新草稿并开始编辑, 编辑完成后使用`ScriptFile.save()`保存即可
 
         Args:
@@ -72,6 +74,8 @@ class DraftFolder:
             fps (`int`, optional): 视频帧率. 默认为30.
             maintrack_adsorb (`bool`, optional): 是否启用主轨道吸附（主轨磁吸）. 默认启用.
             allow_replace (`bool`, optional): 是否允许覆盖与`draft_name`重名的草稿. 默认为否.
+            enable_free_index_mode (`bool`, optional): 是否启用自由层级模式. 默认为否.
+            enable_render_index_track_mode (`bool`, optional): 是否启用轨道渲染索引模式. 默认为否.
 
         Raises:
             `FileExistsError`: 已存在与`draft_name`重名的草稿, 但不允许覆盖.
@@ -87,7 +91,9 @@ class DraftFolder:
         shutil.copy(assets.get_asset_path("DRAFT_META_TEMPLATE"), os.path.join(draft_path, "draft_meta_info.json"))
 
         # 创建草稿文件
-        script_file = ScriptFile(width, height, fps, maintrack_adsorb)
+        script_file = ScriptFile(width, height, fps, maintrack_adsorb,
+                                 enable_free_index_mode=enable_free_index_mode,
+                                 enable_render_index_track_mode=enable_render_index_track_mode)
         script_file.save_path = os.path.join(draft_path, "draft_content.json")
 
         return script_file

--- a/pyJianYingDraft/local_materials.py
+++ b/pyJianYingDraft/local_materials.py
@@ -2,7 +2,7 @@ import os
 import uuid
 import pymediainfo
 
-from typing import Optional, Literal
+from typing import Optional, Literal, List
 from typing import Dict, Any
 
 class CropSettings:
@@ -43,6 +43,40 @@ class CropSettings:
             "lower_right_y": self.lower_right_y
         }
 
+class VideoMaterialMatting:
+    """视频素材的智能抠像设置"""
+
+    flag: int
+    """抠像标记, 3 表示智能人像抠像"""
+    path: str
+    """剪映生成的抠像缓存路径, 新建素材时通常为空"""
+    has_use_quick_brush: bool
+    has_use_quick_eraser: bool
+    interactive_time: List[Any]
+    strokes: List[Any]
+
+    def __init__(self, flag: int = 3, path: str = "",
+                 has_use_quick_brush: bool = False, has_use_quick_eraser: bool = False,
+                 interactive_time: Optional[List[Any]] = None, strokes: Optional[List[Any]] = None):
+        self.flag = flag
+        self.path = path
+        self.has_use_quick_brush = has_use_quick_brush
+        self.has_use_quick_eraser = has_use_quick_eraser
+        self.interactive_time = interactive_time if interactive_time is not None else []
+        self.strokes = strokes if strokes is not None else []
+
+    def export_json(self) -> Dict[str, Any]:
+        matting_json = {
+            "flag": self.flag,
+            "has_use_quick_brush": self.has_use_quick_brush,
+            "has_use_quick_eraser": self.has_use_quick_eraser,
+            "interactiveTime": self.interactive_time,
+            "strokes": self.strokes
+        }
+        if self.path:
+            matting_json["path"] = self.path
+        return matting_json
+
 class VideoMaterial:
     """本地视频素材（视频或图片）, 一份素材可以在多个片段中使用"""
 
@@ -64,6 +98,8 @@ class VideoMaterial:
     """素材裁剪设置"""
     material_type: Literal["video", "photo"]
     """素材类型: 视频或图片"""
+    matting: Optional[VideoMaterialMatting]
+    """智能抠像设置, 为空时不启用"""
 
     def __init__(self, path: str, material_name: Optional[str] = None, crop_settings: CropSettings = CropSettings()):
         """从指定位置加载视频（或图片）素材
@@ -87,6 +123,7 @@ class VideoMaterial:
         self.path = path
         self.crop_settings = crop_settings
         self.local_material_id = ""
+        self.matting = None
 
         if not pymediainfo.MediaInfo.can_parse():
             raise ValueError(f"不支持的视频素材类型 '{postfix}'")
@@ -134,6 +171,8 @@ class VideoMaterial:
             "type": self.material_type,
             "width": self.width
         }
+        if self.matting is not None:
+            video_material_json["matting"] = self.matting.export_json()
         return video_material_json
 
 class AudioMaterial:

--- a/pyJianYingDraft/local_materials.py
+++ b/pyJianYingDraft/local_materials.py
@@ -1,6 +1,8 @@
 import os
+import json
 import uuid
 import pymediainfo
+from copy import deepcopy
 
 from typing import Optional, Literal, List
 from typing import Dict, Any
@@ -174,6 +176,176 @@ class VideoMaterial:
         if self.matting is not None:
             video_material_json["matting"] = self.matting.export_json()
         return video_material_json
+
+class CombinationMaterial:
+    """复合片段素材, 对应剪映草稿中的 ``materials.drafts``。
+
+    复合片段在时间线上仍由 ``VideoSegment`` 承载。剪映格式还要求
+    ``materials.videos`` 中存在一个外层占位视频素材, 该占位 JSON 由
+    本类的 ``export_video_json`` 生成, 但不作为独立素材类型暴露。
+    """
+
+    id: str
+    """复合片段素材 ID, 写入 ``materials.drafts[].id``。"""
+    combination_id: str
+    """剪映组合 ID, 写入 ``materials.drafts[].combination_id``。"""
+    material_id: str
+    """外层 ``VideoSegment.material_id`` 引用的占位视频素材 ID。"""
+    material_name: str
+    """复合片段名称。"""
+    duration: int
+    """复合片段时长, 单位为微秒。"""
+    width: int
+    height: int
+    draft: Dict[str, Any]
+    """嵌套草稿 JSON。"""
+
+    def __init__(self, draft: Any, *, name: str, duration: int, width: int, height: int):
+        self.id = str(uuid.uuid4()).upper()
+        self.combination_id = str(uuid.uuid4()).upper()
+        self.material_id = str(uuid.uuid4()).upper()
+        self.material_name = name
+        self.duration = duration
+        self.width = width
+        self.height = height
+
+        self.canvas_id = str(uuid.uuid4()).upper()
+        self.sound_channel_mapping_id = str(uuid.uuid4()).upper()
+        self.vocal_separation_id = str(uuid.uuid4()).upper()
+
+        if hasattr(draft, "dumps"):
+            self.draft = json.loads(draft.dumps())
+        elif isinstance(draft, dict):
+            self.draft = deepcopy(draft)
+        else:
+            raise TypeError("draft must be a ScriptFile-like object or a dict")
+
+    def build_segment_extra_material_refs(self, speed_id: str) -> List[str]:
+        """返回外层复合片段需要引用的素材 ID。"""
+        return [
+            self.id,
+            speed_id,
+            self.canvas_id,
+            self.sound_channel_mapping_id,
+            self.vocal_separation_id,
+        ]
+
+    def export_json(self) -> Dict[str, Any]:
+        """导出到 ``materials.drafts``。"""
+        return {
+            "category_id": "",
+            "category_name": "",
+            "combination_id": self.combination_id,
+            "draft": deepcopy(self.draft),
+            "formula_id": "",
+            "id": self.id,
+            "name": "",
+            "precompile_combination": False,
+            "type": "combination",
+        }
+
+    def export_video_json(self) -> Dict[str, Any]:
+        """导出剪映要求放在 ``materials.videos`` 的外层占位项。"""
+        return {
+            "aigc_type": "none",
+            "audio_fade": None,
+            "cartoon_path": "",
+            "category_id": "",
+            "category_name": "",
+            "check_flag": 63487,
+            "crop": CropSettings().export_json(),
+            "crop_ratio": "free",
+            "crop_scale": 1.0,
+            "duration": self.duration,
+            "extra_type_option": 2,
+            "formula_id": "",
+            "freeze": None,
+            "has_audio": True,
+            "height": self.height,
+            "id": self.material_id,
+            "intensifies_audio_path": "",
+            "intensifies_path": "",
+            "is_ai_generate_content": False,
+            "is_copyright": True,
+            "is_text_edit_overdub": False,
+            "is_unified_beauty_mode": False,
+            "local_id": "",
+            "local_material_id": "",
+            "material_id": "",
+            "material_name": self.material_name,
+            "material_url": "",
+            "matting": {
+                "flag": 0,
+                "has_use_quick_brush": False,
+                "has_use_quick_eraser": False,
+                "interactiveTime": [],
+                "path": "",
+                "strokes": [],
+            },
+            "media_path": "",
+            "object_locked": None,
+            "origin_material_id": "",
+            "path": "",
+            "picture_from": "none",
+            "picture_set_category_id": "",
+            "picture_set_category_name": "",
+            "request_id": "",
+            "reverse_intensifies_path": "",
+            "reverse_path": "",
+            "smart_motion": None,
+            "source": 0,
+            "source_platform": 0,
+            "stable": {
+                "matrix_path": "",
+                "stable_level": 0,
+                "time_range": {"duration": 0, "start": 0},
+            },
+            "team_id": "",
+            "type": "video",
+            "video_algorithm": {
+                "algorithms": [],
+                "complement_frame_config": None,
+                "deflicker": None,
+                "gameplay_configs": [],
+                "motion_blur_config": None,
+                "noise_reduction": None,
+                "path": "",
+                "quality_enhance": None,
+                "time_range": None,
+            },
+            "width": self.width,
+        }
+
+    def export_canvas_json(self) -> Dict[str, Any]:
+        return {
+            "album_image": "",
+            "blur": 0.0,
+            "color": "",
+            "id": self.canvas_id,
+            "image": "",
+            "image_id": "",
+            "image_name": "",
+            "source_platform": 0,
+            "team_id": "",
+            "type": "canvas_color",
+        }
+
+    def export_sound_channel_mapping_json(self) -> Dict[str, Any]:
+        return {
+            "audio_channel_mapping": 0,
+            "id": self.sound_channel_mapping_id,
+            "is_config_open": False,
+            "type": "",
+        }
+
+    def export_vocal_separation_json(self) -> Dict[str, Any]:
+        return {
+            "choice": 0,
+            "id": self.vocal_separation_id,
+            "production_path": "",
+            "time_range": None,
+            "type": "vocal_separation",
+        }
 
 class AudioMaterial:
     """本地音频素材"""

--- a/pyJianYingDraft/local_materials.py
+++ b/pyJianYingDraft/local_materials.py
@@ -197,10 +197,13 @@ class CombinationMaterial:
     """复合片段时长, 单位为微秒。"""
     width: int
     height: int
+    matting: Optional[VideoMaterialMatting]
+    """智能抠像设置, 为空时不启用。"""
     draft: Dict[str, Any]
     """嵌套草稿 JSON。"""
 
-    def __init__(self, draft: Any, *, name: str, duration: int, width: int, height: int):
+    def __init__(self, draft: Any, *, name: str, duration: int, width: int, height: int,
+                 matting: Optional[VideoMaterialMatting] = None):
         self.id = str(uuid.uuid4()).upper()
         self.combination_id = str(uuid.uuid4()).upper()
         self.material_id = str(uuid.uuid4()).upper()
@@ -208,6 +211,7 @@ class CombinationMaterial:
         self.duration = duration
         self.width = width
         self.height = height
+        self.matting = matting
 
         self.canvas_id = str(uuid.uuid4()).upper()
         self.sound_channel_mapping_id = str(uuid.uuid4()).upper()
@@ -219,6 +223,22 @@ class CombinationMaterial:
             self.draft = deepcopy(draft)
         else:
             raise TypeError("draft must be a ScriptFile-like object or a dict")
+
+    def _export_matting_json(self) -> Dict[str, Any]:
+        if self.matting is None:
+            return {
+                "flag": 0,
+                "has_use_quick_brush": False,
+                "has_use_quick_eraser": False,
+                "interactiveTime": [],
+                "path": "",
+                "strokes": [],
+            }
+
+        matting_json = self.matting.export_json()
+        if "path" not in matting_json:
+            matting_json["path"] = ""
+        return matting_json
 
     def build_segment_extra_material_refs(self, speed_id: str) -> List[str]:
         """返回外层复合片段需要引用的素材 ID。"""
@@ -274,14 +294,7 @@ class CombinationMaterial:
             "material_id": "",
             "material_name": self.material_name,
             "material_url": "",
-            "matting": {
-                "flag": 0,
-                "has_use_quick_brush": False,
-                "has_use_quick_eraser": False,
-                "interactiveTime": [],
-                "path": "",
-                "strokes": [],
-            },
+            "matting": self._export_matting_json(),
             "media_path": "",
             "object_locked": None,
             "origin_material_id": "",

--- a/pyJianYingDraft/local_materials.py
+++ b/pyJianYingDraft/local_materials.py
@@ -93,13 +93,36 @@ class VideoMaterialMatting:
 
     def __init__(self, flag: int = 3, path: str = "",
                  has_use_quick_brush: bool = False, has_use_quick_eraser: bool = False,
-                 interactive_time: Optional[List[Any]] = None, strokes: Optional[List[Any]] = None):
+                 interactive_time: Optional[List[Any]] = None, strokes: Optional[List[Any]] = None,
+                 *, reuse_cache: bool = False):
+        interactive_time = interactive_time if interactive_time is not None else []
+        strokes = strokes if strokes is not None else []
+        if not reuse_cache and (
+            path or has_use_quick_brush or has_use_quick_eraser or interactive_time or strokes
+        ):
+            raise ValueError("matting cache fields require reuse_cache=True")
+
         self.flag = flag
         self.path = path
         self.has_use_quick_brush = has_use_quick_brush
         self.has_use_quick_eraser = has_use_quick_eraser
-        self.interactive_time = interactive_time if interactive_time is not None else []
-        self.strokes = strokes if strokes is not None else []
+        self.interactive_time = interactive_time
+        self.strokes = strokes
+
+    def clone(self, *, reuse_cache: bool = False) -> "VideoMaterialMatting":
+        """复制抠像设置，默认只保留抠像标记并丢弃剪映缓存状态。"""
+        if not reuse_cache:
+            return VideoMaterialMatting(flag=self.flag)
+
+        return VideoMaterialMatting(
+            flag=self.flag,
+            path=self.path,
+            has_use_quick_brush=self.has_use_quick_brush,
+            has_use_quick_eraser=self.has_use_quick_eraser,
+            interactive_time=deepcopy(self.interactive_time),
+            strokes=deepcopy(self.strokes),
+            reuse_cache=True,
+        )
 
     def export_json(self) -> Dict[str, Any]:
         matting_json = {
@@ -246,7 +269,7 @@ class CombinationMaterial:
     """嵌套草稿 JSON。"""
 
     def __init__(self, draft: Any, *, name: str, duration: int, width: int, height: int,
-                 matting: Optional[VideoMaterialMatting] = None):
+                 matting: Optional[VideoMaterialMatting] = None, reuse_matting_cache: bool = False):
         self.id = str(uuid.uuid4()).upper()
         self.combination_id = str(uuid.uuid4()).upper()
         self.material_id = str(uuid.uuid4()).upper()
@@ -254,7 +277,7 @@ class CombinationMaterial:
         self.duration = duration
         self.width = width
         self.height = height
-        self.matting = matting
+        self.matting = matting.clone(reuse_cache=reuse_matting_cache) if matting is not None else None
 
         self.canvas_id = str(uuid.uuid4()).upper()
         self.sound_channel_mapping_id = str(uuid.uuid4()).upper()

--- a/pyJianYingDraft/script_file.py
+++ b/pyJianYingDraft/script_file.py
@@ -11,7 +11,7 @@ from . import assets
 from . import exceptions
 from .template_mode import ImportedTrack, EditableTrack, ImportedMediaTrack, ImportedTextTrack, ShrinkMode, ExtendMode, import_track
 from .time_util import Timerange, tim, srt_tstamp
-from .local_materials import VideoMaterial, AudioMaterial
+from .local_materials import CombinationMaterial, VideoMaterial, AudioMaterial
 from .segment import BaseSegment, Speed, ClipSettings
 from .audio_segment import AudioSegment, AudioFade, AudioEffect
 from .video_segment import VideoSegment, StickerSegment, SegmentAnimations, VideoEffect, Transition, Filter, BackgroundFilling, MixMode
@@ -21,6 +21,11 @@ from .track import TrackType, BaseTrack, Track
 
 from .metadata import VideoSceneEffectType, VideoCharacterEffectType, FilterType
 
+def _export_material_item(item: Any) -> Dict[str, Any]:
+    if isinstance(item, dict):
+        return deepcopy(item)
+    return item.export_json()
+
 class ScriptMaterial:
     """草稿文件中的素材信息部分"""
 
@@ -28,6 +33,8 @@ class ScriptMaterial:
     """音频素材列表"""
     videos: List[VideoMaterial]
     """视频素材列表"""
+    drafts: List[CombinationMaterial]
+    """复合片段素材列表"""
     stickers: List[Dict[str, Any]]
     """贴纸素材列表"""
     texts: List[Dict[str, Any]]
@@ -54,10 +61,15 @@ class ScriptMaterial:
     """混合模式列表, 导出到`effects`中"""
     canvases: List[BackgroundFilling]
     """背景填充列表"""
+    sound_channel_mappings: List[Dict[str, Any]]
+    """声道映射列表"""
+    vocal_separations: List[Dict[str, Any]]
+    """人声分离列表"""
 
     def __init__(self):
         self.audios = []
         self.videos = []
+        self.drafts = []
         self.stickers = []
         self.texts = []
 
@@ -72,6 +84,8 @@ class ScriptMaterial:
         self.filters = []
         self.mix_modes = []
         self.canvases = []
+        self.sound_channel_mappings = []
+        self.vocal_separations = []
 
     @overload
     def __contains__(self, item: Union[VideoMaterial, AudioMaterial]) -> bool: ...
@@ -83,6 +97,8 @@ class ScriptMaterial:
     def __contains__(self, item) -> bool:
         if isinstance(item, VideoMaterial):
             return item.material_id in [video.material_id for video in self.videos]
+        elif isinstance(item, CombinationMaterial):
+            return item.id in [draft.id for draft in self.drafts]
         elif isinstance(item, AudioMaterial):
             return item.material_id in [audio.material_id for audio in self.audios]
         elif isinstance(item, AudioFade):
@@ -111,11 +127,11 @@ class ScriptMaterial:
             "audio_track_indexes": [],
             "audios": [audio.export_json() for audio in self.audios],
             "beats": [],
-            "canvases": [canvas.export_json() for canvas in self.canvases],
+            "canvases": [_export_material_item(canvas) for canvas in self.canvases],
             "chromas": [],
             "color_curves": [],
             "digital_humans": [],
-            "drafts": [],
+            "drafts": [draft.export_json() for draft in self.drafts],
             "effects": [_filter.export_json() for _filter in self.filters] + [mix_mode.export_json() for mix_mode in self.mix_modes],
             "flowers": [],
             "green_screens": [],
@@ -136,7 +152,7 @@ class ScriptMaterial:
             "shapes": [],
             "smart_crops": [],
             "smart_relights": [],
-            "sound_channel_mappings": [],
+            "sound_channel_mappings": [_export_material_item(mapping) for mapping in self.sound_channel_mappings],
             "speeds": [spd.export_json() for spd in self.speeds],
             "stickers": self.stickers,
             "tail_leaders": [],
@@ -146,9 +162,9 @@ class ScriptMaterial:
             "transitions": [transition.export_json() for transition in self.transitions],
             "video_effects": [effect.export_json() for effect in self.video_effects],
             "video_trackings": [],
-            "videos": [video.export_json() for video in self.videos],
+            "videos": [video.export_json() for video in self.videos] + [draft.export_video_json() for draft in self.drafts],
             "vocal_beautifys": [],
-            "vocal_separations": []
+            "vocal_separations": [_export_material_item(separation) for separation in self.vocal_separations]
         }
 
 class ScriptFile:
@@ -317,26 +333,18 @@ class ScriptFile:
 
         return next(track for track in self.tracks.values() if track.accept_segment_type == segment_type)
 
-    def add_segment(self, segment: Union[VideoSegment, StickerSegment, AudioSegment, TextSegment],
-                    track_name: Optional[str] = None) -> "ScriptFile":
-        """向指定轨道中添加一个片段
+    @staticmethod
+    def _append_raw_material_once(material_list: List[Any], material_json: Dict[str, Any]) -> None:
+        material_id = material_json.get("id")
+        for material in material_list:
+            if isinstance(material, dict) and material.get("id") == material_id:
+                return
+            if getattr(material, "global_id", None) == material_id:
+                return
+        material_list.append(material_json)
 
-        Args:
-            segment (`VideoSegment`, `StickerSegment`, `AudioSegment`, or `TextSegment`): 要添加的片段
-            track_name (`str`, optional): 添加到的轨道名称. 当此类型的轨道仅有一条时可省略.
-
-        Raises:
-            `NameError`: 未找到指定名称的轨道, 或必须提供`track_name`参数时未提供
-            `TypeError`: 片段类型不匹配轨道类型
-            `SegmentOverlap`: 新片段与已有片段重叠
-        """
-        target = self._get_track(type(segment), track_name)
-
-        # 加入轨道并更新时长
-        target.add_segment(segment)
-        self.duration = max(self.duration, segment.end)
-
-        # 自动添加相关素材
+    def _register_segment_materials(self, segment: Union[VideoSegment, StickerSegment, AudioSegment, TextSegment]) -> None:
+        """收集片段引用的素材到草稿素材表。"""
         if isinstance(segment, VideoSegment):
             # 出入场等动画
             if (segment.animations_instance is not None) and (segment.animations_instance not in self.materials):
@@ -366,6 +374,22 @@ class ScriptFile:
                 self.materials.canvases.append(segment.background_filling)
 
             self.materials.speeds.append(segment.speed)
+
+            if isinstance(segment.material_instance, CombinationMaterial):
+                material = segment.material_instance
+                if material not in self.materials:
+                    self.materials.drafts.append(material)
+                self._append_raw_material_once(self.materials.canvases, material.export_canvas_json())
+                self._append_raw_material_once(
+                    self.materials.sound_channel_mappings,
+                    material.export_sound_channel_mapping_json(),
+                )
+                self._append_raw_material_once(
+                    self.materials.vocal_separations,
+                    material.export_vocal_separation_json(),
+                )
+            else:
+                self.add_material(segment.material_instance)
         elif isinstance(segment, StickerSegment):
             self.materials.stickers.append(segment.export_material())
         elif isinstance(segment, AudioSegment):
@@ -377,6 +401,7 @@ class ScriptFile:
                 if effect not in self.materials:
                     self.materials.audio_effects.append(effect)
             self.materials.speeds.append(segment.speed)
+            self.add_material(segment.material_instance)
         elif isinstance(segment, TextSegment):
             # 出入场等动画
             if (segment.animations_instance is not None) and (segment.animations_instance not in self.materials):
@@ -390,11 +415,114 @@ class ScriptFile:
             # 字体样式
             self.materials.texts.append(segment.export_material())
 
-        # 添加片段素材
-        if isinstance(segment, (VideoSegment, AudioSegment)):
-            self.add_material(segment.material_instance)
+    def _rebuild_materials_from_tracks(self) -> None:
+        self.materials = ScriptMaterial()
+        self.duration = max([getattr(track, "end_time", 0) for track in self.imported_tracks], default=0)
+        for track in self.tracks.values():
+            for segment in track.segments:
+                self._register_segment_materials(segment)
+                self.duration = max(self.duration, segment.end)
+
+    def add_segment(self, segment: Union[VideoSegment, StickerSegment, AudioSegment, TextSegment],
+                    track_name: Optional[str] = None) -> "ScriptFile":
+        """向指定轨道中添加一个片段
+
+        Args:
+            segment (`VideoSegment`, `StickerSegment`, `AudioSegment`, or `TextSegment`): 要添加的片段
+            track_name (`str`, optional): 添加到的轨道名称. 当此类型的轨道仅有一条时可省略.
+
+        Raises:
+            `NameError`: 未找到指定名称的轨道, 或必须提供`track_name`参数时未提供
+            `TypeError`: 片段类型不匹配轨道类型
+            `SegmentOverlap`: 新片段与已有片段重叠
+        """
+        target = self._get_track(type(segment), track_name)
+
+        # 加入轨道并更新时长
+        target.add_segment(segment)
+        self.duration = max(self.duration, segment.end)
+
+        # 自动添加相关素材
+        self._register_segment_materials(segment)
 
         return self
+
+    def compose_segments(self, track_name: str, segment_indices: Optional[List[int]] = None, *,
+                         name: str = "复合片段1") -> VideoSegment:
+        """将同一视频轨道上的多个片段组成复合片段。
+
+        复合片段在时间线上仍表现为一个 ``VideoSegment``，该片段引用
+        ``CombinationMaterial``。第一版仅支持当前草稿中新建的普通视频轨道,
+        不处理模板导入轨道。
+
+        Args:
+            track_name (`str`): 要组合的轨道名称。
+            segment_indices (`List[int]`, optional): 要组合的片段下标。默认组合整条轨道。
+            name (`str`, optional): 复合片段名称。
+
+        Returns:
+            `VideoSegment`: 外层时间线上的复合片段。
+
+        Raises:
+            `NameError`: 轨道不存在。
+            `TypeError`: 指定轨道不是视频轨道。
+            `ValueError`: 片段选择为空、不连续或下标越界。
+        """
+        if track_name not in self.tracks:
+            raise NameError("不存在名为 '%s' 的轨道" % track_name)
+
+        track = self.tracks[track_name]
+        if track.track_type != TrackType.video:
+            raise TypeError("只能组合视频轨道片段")
+        if len(track.segments) == 0:
+            raise ValueError("不能组合空轨道")
+
+        if segment_indices is None:
+            indices = list(range(len(track.segments)))
+        else:
+            indices = sorted(set(segment_indices))
+        if len(indices) == 0:
+            raise ValueError("未选择任何片段")
+        if indices[0] < 0 or indices[-1] >= len(track.segments):
+            raise ValueError("片段下标超出范围")
+        if indices != list(range(indices[0], indices[-1] + 1)):
+            raise ValueError("复合片段第一版只支持连续片段下标")
+
+        selected_segments = [track.segments[index] for index in indices]
+        compound_start = min(segment.start for segment in selected_segments)
+        compound_end = max(segment.end for segment in selected_segments)
+        compound_duration = compound_end - compound_start
+
+        nested = ScriptFile(self.width, self.height, self.fps, False)
+        nested.add_track(track.track_type, track.name, mute=track.mute, absolute_index=track.render_index)
+        for segment in selected_segments:
+            nested_segment = deepcopy(segment)
+            nested_segment.start = nested_segment.start - compound_start
+            nested.add_segment(nested_segment, track.name)
+
+        combination_material = CombinationMaterial(
+            nested,
+            name=name,
+            duration=compound_duration,
+            width=self.width,
+            height=self.height,
+        )
+        combination_segment = VideoSegment(
+            combination_material,
+            Timerange(compound_start, compound_duration),
+            source_timerange=Timerange(0, compound_duration),
+        )
+
+        first_index = indices[0]
+        last_index = indices[-1]
+        track.segments = (
+            track.segments[:first_index]
+            + [combination_segment]
+            + track.segments[last_index + 1:]
+        )
+        self._rebuild_materials_from_tracks()
+
+        return combination_segment
 
     def add_effect(self, effect: Union[VideoSceneEffectType, VideoCharacterEffectType],
                    t_range: Timerange, track_name: Optional[str] = None, *,

--- a/pyJianYingDraft/script_file.py
+++ b/pyJianYingDraft/script_file.py
@@ -181,7 +181,9 @@ class ScriptFile:
     imported_tracks: List[ImportedTrack]
     """导入的轨道信息"""
 
-    def __init__(self, width: int, height: int, fps: int, maintrack_adsorb: bool):
+    def __init__(self, width: int, height: int, fps: int, maintrack_adsorb: bool, *,
+                 enable_free_index_mode: bool = False,
+                 enable_render_index_track_mode: bool = False):
         """**创建剪映草稿推荐使用`DraftFolder.create_draft()`而非此方法**
 
         Args:
@@ -189,6 +191,8 @@ class ScriptFile:
             height (int): 视频高度, 单位为像素
             fps (int): 视频帧率
             maintrack_adsorb (bool): 是否启用主轨道吸附（主轨磁吸）
+            enable_free_index_mode (bool, optional): 是否启用自由层级模式.
+            enable_render_index_track_mode (bool, optional): 是否启用轨道渲染索引模式.
         """
         self.save_path = None
 
@@ -206,6 +210,26 @@ class ScriptFile:
 
         with open(assets.get_asset_path('DRAFT_CONTENT_TEMPLATE'), "r", encoding="utf-8") as f:
             self.content = json.load(f)
+        if enable_free_index_mode:
+            self.content["free_render_index_mode_on"] = True
+        if enable_render_index_track_mode:
+            self.content["render_index_track_mode_on"] = True
+
+    def enable_free_index_mode(self, enable: bool = True) -> "ScriptFile":
+        """启用或禁用自由层级模式"""
+        self.content["free_render_index_mode_on"] = enable
+        return self
+
+    def enable_render_index_track_mode(self, enable: bool = True) -> "ScriptFile":
+        """启用或禁用轨道渲染索引模式"""
+        self.content["render_index_track_mode_on"] = enable
+        return self
+
+    def set_both_index_modes(self, enable: bool = True) -> "ScriptFile":
+        """同时设置自由层级模式和轨道渲染索引模式"""
+        self.enable_free_index_mode(enable)
+        self.enable_render_index_track_mode(enable)
+        return self
 
     @staticmethod
     def load_template(json_path: str) -> "ScriptFile":

--- a/pyJianYingDraft/video_segment.py
+++ b/pyJianYingDraft/video_segment.py
@@ -11,7 +11,7 @@ from typing import Dict, List, Tuple, Any
 
 from .time_util import tim, Timerange
 from .segment import VisualSegment, ClipSettings, AudioFade
-from .local_materials import VideoMaterial
+from .local_materials import VideoMaterial, VideoMaterialMatting
 from .animation import SegmentAnimations, VideoAnimation
 
 from .metadata import EffectMeta, EffectParamInstance
@@ -497,6 +497,16 @@ class VideoSegment(VisualSegment):
         self.mix_modes.append(mix_mode_inst)
         self.extra_material_refs.append(mix_mode_inst.global_id)
 
+        return self
+
+    def add_smart_matting(self, *, path: str = "") -> "VideoSegment":
+        """为视频素材添加智能人像抠像标记
+
+        Args:
+            path (`str`, optional): 剪映生成的抠像缓存路径. 默认不写入缓存路径,
+                由剪映在打开或导出草稿时生成.
+        """
+        self.material_instance.matting = VideoMaterialMatting(path=path)
         return self
 
     def add_mask(self, mask_type: MaskType, *, center_x: float = 0.0, center_y: float = 0.0, size: float = 0.5,

--- a/pyJianYingDraft/video_segment.py
+++ b/pyJianYingDraft/video_segment.py
@@ -11,7 +11,7 @@ from typing import Dict, List, Tuple, Any
 
 from .time_util import tim, Timerange
 from .segment import VisualSegment, ClipSettings, AudioFade
-from .local_materials import VideoMaterial, VideoMaterialMatting
+from .local_materials import CombinationMaterial, VideoMaterial, VideoMaterialMatting
 from .animation import SegmentAnimations, VideoAnimation
 
 from .metadata import EffectMeta, EffectParamInstance
@@ -315,7 +315,7 @@ class MixMode:
 class VideoSegment(VisualSegment):
     """安放在轨道上的一个视频/图片片段"""
 
-    material_instance: VideoMaterial
+    material_instance: Union[VideoMaterial, CombinationMaterial]
     """素材实例"""
     material_size: Tuple[int, int]
     """素材尺寸"""
@@ -357,13 +357,13 @@ class VideoSegment(VisualSegment):
     在放入轨道时自动添加到素材列表中
     """
 
-    def __init__(self, material: Union[VideoMaterial, str], target_timerange: Timerange, *,
+    def __init__(self, material: Union[VideoMaterial, CombinationMaterial, str], target_timerange: Timerange, *,
                  source_timerange: Optional[Timerange] = None, speed: Optional[float] = None, volume: float = 1.0,
                  change_pitch: bool = False, clip_settings: Optional[ClipSettings] = None):
         """利用给定的视频/图片素材构建一个轨道片段, 并指定其时间信息及图像调节设置
 
         Args:
-            material (`VideoMaterial` or `str`): 素材实例或素材路径, 若为路径则自动构造素材实例(此时不能指定`cropSettings`参数)
+            material (`VideoMaterial`, `CombinationMaterial` or `str`): 素材实例或素材路径, 若为路径则自动构造素材实例(此时不能指定`cropSettings`参数)
             target_timerange (`Timerange`): 片段在轨道上的目标时间范围
             source_timerange (`Timerange`, optional): 截取的素材片段的时间范围, 默认从开头根据`speed`截取与`target_timerange`等长的一部分
             speed (`float`, optional): 播放速度, 默认为1.0. 此项与`source_timerange`同时指定时, 将覆盖`target_timerange`中的时长
@@ -400,6 +400,9 @@ class VideoSegment(VisualSegment):
         self.mask = None
         self.background_filling = None
         self.fade = None
+
+        if isinstance(material, CombinationMaterial):
+            self.extra_material_refs = material.build_segment_extra_material_refs(self.speed.global_id)
 
     def add_animation(self, animation_type: Union[IntroType, OutroType, GroupAnimationType],
                       duration: Optional[Union[int, str]] = None) -> "VideoSegment":
@@ -506,6 +509,8 @@ class VideoSegment(VisualSegment):
             path (`str`, optional): 剪映生成的抠像缓存路径. 默认不写入缓存路径,
                 由剪映在打开或导出草稿时生成.
         """
+        if isinstance(self.material_instance, CombinationMaterial):
+            raise TypeError("复合片段不能直接添加智能抠像, 请对嵌套素材片段添加")
         self.material_instance.matting = VideoMaterialMatting(path=path)
         return self
 

--- a/pyJianYingDraft/video_segment.py
+++ b/pyJianYingDraft/video_segment.py
@@ -502,14 +502,19 @@ class VideoSegment(VisualSegment):
 
         return self
 
-    def add_smart_matting(self, *, path: str = "") -> "VideoSegment":
+    def add_smart_matting(self, *, path: str = "", reuse_cache: bool = False) -> "VideoSegment":
         """为视频素材添加智能人像抠像标记
 
         Args:
             path (`str`, optional): 剪映生成的抠像缓存路径. 默认不写入缓存路径,
                 由剪映在打开或导出草稿时生成.
+            reuse_cache (`bool`, optional): 是否显式复用已生成的剪映抠像缓存.
+                默认为否, 以避免不同素材之间误用旧的人像轮廓.
         """
-        self.material_instance.matting = VideoMaterialMatting(path=path)
+        self.material_instance.matting = VideoMaterialMatting(
+            path=path,
+            reuse_cache=reuse_cache,
+        )
         return self
 
     def add_mask(self, mask_type: MaskType, *, center_x: float = 0.0, center_y: float = 0.0, size: float = 0.5,

--- a/pyJianYingDraft/video_segment.py
+++ b/pyJianYingDraft/video_segment.py
@@ -509,8 +509,6 @@ class VideoSegment(VisualSegment):
             path (`str`, optional): 剪映生成的抠像缓存路径. 默认不写入缓存路径,
                 由剪映在打开或导出草稿时生成.
         """
-        if isinstance(self.material_instance, CombinationMaterial):
-            raise TypeError("复合片段不能直接添加智能抠像, 请对嵌套素材片段添加")
         self.material_instance.matting = VideoMaterialMatting(path=path)
         return self
 

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,18 @@
+from pathlib import Path
+
 from setuptools import setup, find_packages
+
+
+readme_path = Path("pypi_readme.md")
+if not readme_path.exists():
+    readme_path = Path("README.md")
 
 setup(
     name="pyjianyingdraft",
     version="0.2.6",
     author="gary318",
     description="轻量、灵活、易上手的Python剪映草稿生成及导出工具，构建全自动化视频剪辑/混剪流水线",
-    long_description=open("pypi_readme.md", "r", encoding="utf-8").read(),
+    long_description=readme_path.read_text(encoding="utf-8"),
     long_description_content_type="text/markdown",
     url="https://github.com/GuanYixuan/pyJianYingDraft",
     packages=find_packages(exclude=["tools", "tools.*", "ignored", "ignored.*"]),

--- a/tests/test_combination_material.py
+++ b/tests/test_combination_material.py
@@ -4,7 +4,7 @@ import uuid
 import pyJianYingDraft as draft
 
 
-def _make_video_material(name: str) -> draft.VideoMaterial:
+def _make_video_material(name: str, *, smart_matting: bool = False) -> draft.VideoMaterial:
     material = draft.VideoMaterial.__new__(draft.VideoMaterial)
     material.material_id = uuid.uuid4().hex
     material.local_material_id = ""
@@ -15,7 +15,7 @@ def _make_video_material(name: str) -> draft.VideoMaterial:
     material.height = 1920
     material.crop_settings = draft.CropSettings()
     material.material_type = "video"
-    material.matting = draft.VideoMaterialMatting()
+    material.matting = draft.VideoMaterialMatting() if smart_matting else None
     return material
 
 
@@ -64,6 +64,34 @@ def test_compose_segments_exports_combination_material() -> None:
     ]
     assert len(nested["materials"]["videos"]) == 3
     assert {
-        material["matting"]["flag"]
+        material.get("matting", {}).get("flag", 0)
         for material in nested["materials"]["videos"]
-    } == {3}
+    } == {0}
+
+
+def test_compound_segment_can_enable_smart_matting_on_outer_material() -> None:
+    script = draft.ScriptFile(1080, 1920, 30, True)
+    script.add_track(draft.TrackType.video, "video")
+
+    for index in range(3):
+        segment = draft.VideoSegment(
+            _make_video_material(f"clip_{index}.mp4"),
+            draft.Timerange(index * 10_000_000, 10_000_000),
+            source_timerange=draft.Timerange(0, 10_000_000),
+        )
+        script.add_segment(segment, "video")
+
+    combination_segment = script.compose_segments("video", name="复合片段1")
+    returned = combination_segment.add_smart_matting()
+    exported = json.loads(script.dumps())
+
+    assert returned is combination_segment
+    assert len(exported["materials"]["videos"]) == 1
+    assert exported["materials"]["videos"][0]["matting"]["flag"] == 3
+    assert exported["materials"]["videos"][0]["matting"]["path"] == ""
+
+    nested = exported["materials"]["drafts"][0]["draft"]
+    assert {
+        material.get("matting", {}).get("flag", 0)
+        for material in nested["materials"]["videos"]
+    } == {0}

--- a/tests/test_combination_material.py
+++ b/tests/test_combination_material.py
@@ -1,0 +1,69 @@
+import json
+import uuid
+
+import pyJianYingDraft as draft
+
+
+def _make_video_material(name: str) -> draft.VideoMaterial:
+    material = draft.VideoMaterial.__new__(draft.VideoMaterial)
+    material.material_id = uuid.uuid4().hex
+    material.local_material_id = ""
+    material.material_name = name
+    material.path = f"C:/fake/{name}"
+    material.duration = 10_000_000
+    material.width = 1080
+    material.height = 1920
+    material.crop_settings = draft.CropSettings()
+    material.material_type = "video"
+    material.matting = draft.VideoMaterialMatting()
+    return material
+
+
+def test_compose_segments_exports_combination_material() -> None:
+    script = draft.ScriptFile(1080, 1920, 30, True)
+    script.add_track(draft.TrackType.video, "video")
+
+    for index in range(3):
+        segment = draft.VideoSegment(
+            _make_video_material(f"clip_{index}.mp4"),
+            draft.Timerange(index * 10_000_000, 10_000_000),
+            source_timerange=draft.Timerange(0, 10_000_000),
+        )
+        script.add_segment(segment, "video")
+
+    combination_segment = script.compose_segments("video", name="复合片段1")
+    exported = json.loads(script.dumps())
+
+    video_segments = [
+        segment
+        for track in exported["tracks"]
+        if track["type"] == "video"
+        for segment in track["segments"]
+    ]
+    assert len(video_segments) == 1
+    assert video_segments[0]["id"] == combination_segment.segment_id
+
+    assert len(exported["materials"]["drafts"]) == 1
+    assert len(exported["materials"]["videos"]) == 1
+    assert exported["materials"]["videos"][0]["material_name"] == "复合片段1"
+    assert exported["materials"]["videos"][0]["extra_type_option"] == 2
+    assert video_segments[0]["material_id"] == exported["materials"]["videos"][0]["id"]
+    assert exported["materials"]["drafts"][0]["id"] in video_segments[0]["extra_material_refs"]
+
+    nested = exported["materials"]["drafts"][0]["draft"]
+    nested_segments = [
+        segment
+        for track in nested["tracks"]
+        if track["type"] == "video"
+        for segment in track["segments"]
+    ]
+    assert [segment["target_timerange"]["start"] for segment in nested_segments] == [
+        0,
+        10_000_000,
+        20_000_000,
+    ]
+    assert len(nested["materials"]["videos"]) == 3
+    assert {
+        material["matting"]["flag"]
+        for material in nested["materials"]["videos"]
+    } == {3}

--- a/tests/test_combination_material.py
+++ b/tests/test_combination_material.py
@@ -1,6 +1,7 @@
 import json
 import uuid
 
+import pytest
 import pyJianYingDraft as draft
 
 
@@ -95,3 +96,127 @@ def test_compound_segment_can_enable_smart_matting_on_outer_material() -> None:
         material.get("matting", {}).get("flag", 0)
         for material in nested["materials"]["videos"]
     } == {0}
+
+
+def test_smart_matting_cache_requires_explicit_reuse() -> None:
+    with pytest.raises(ValueError, match="reuse_cache=True"):
+        draft.VideoMaterialMatting(path="##_draftpath_placeholder_##/matting/cache")
+
+    with pytest.raises(ValueError, match="reuse_cache=True"):
+        draft.VideoMaterialMatting(
+            has_use_quick_brush=True,
+            interactive_time=[100],
+            strokes=[{"x": 1}],
+        )
+
+
+def test_smart_matting_cache_can_be_reused_explicitly() -> None:
+    matting = draft.VideoMaterialMatting(
+        path="##_draftpath_placeholder_##/matting/cache",
+        has_use_quick_brush=True,
+        has_use_quick_eraser=True,
+        interactive_time=[100],
+        strokes=[{"x": 1}],
+        reuse_cache=True,
+    )
+
+    assert matting.export_json() == {
+        "flag": 3,
+        "has_use_quick_brush": True,
+        "has_use_quick_eraser": True,
+        "interactiveTime": [100],
+        "path": "##_draftpath_placeholder_##/matting/cache",
+        "strokes": [{"x": 1}],
+    }
+
+
+def test_add_smart_matting_defaults_to_fresh_cache() -> None:
+    segment = draft.VideoSegment(
+        _make_video_material("clip.mp4"),
+        draft.Timerange(0, 10_000_000),
+        source_timerange=draft.Timerange(0, 10_000_000),
+    )
+
+    with pytest.raises(ValueError, match="reuse_cache=True"):
+        segment.add_smart_matting(
+            path="##_draftpath_placeholder_##/matting/cache",
+        )
+
+    segment.add_smart_matting()
+
+    assert segment.material_instance.matting.export_json() == {
+        "flag": 3,
+        "has_use_quick_brush": False,
+        "has_use_quick_eraser": False,
+        "interactiveTime": [],
+        "strokes": [],
+    }
+
+
+def test_add_smart_matting_can_reuse_cache_explicitly() -> None:
+    segment = draft.VideoSegment(
+        _make_video_material("clip.mp4"),
+        draft.Timerange(0, 10_000_000),
+        source_timerange=draft.Timerange(0, 10_000_000),
+    )
+
+    segment.add_smart_matting(
+        path="##_draftpath_placeholder_##/matting/cache",
+        reuse_cache=True,
+    )
+
+    assert (
+        segment.material_instance.matting.export_json()["path"]
+        == "##_draftpath_placeholder_##/matting/cache"
+    )
+
+
+def test_combination_material_drops_matting_cache_by_default() -> None:
+    matting = draft.VideoMaterialMatting(
+        path="##_draftpath_placeholder_##/matting/cache",
+        has_use_quick_brush=True,
+        interactive_time=[100],
+        strokes=[{"x": 1}],
+        reuse_cache=True,
+    )
+    combination = draft.CombinationMaterial(
+        {"tracks": [], "materials": {"videos": []}},
+        name="复合片段1",
+        duration=10_000_000,
+        width=1080,
+        height=1920,
+        matting=matting,
+    )
+
+    exported = combination.export_video_json()
+
+    assert exported["matting"] == {
+        "flag": 3,
+        "has_use_quick_brush": False,
+        "has_use_quick_eraser": False,
+        "interactiveTime": [],
+        "path": "",
+        "strokes": [],
+    }
+
+
+def test_combination_material_can_reuse_matting_cache_explicitly() -> None:
+    matting = draft.VideoMaterialMatting(
+        path="##_draftpath_placeholder_##/matting/cache",
+        strokes=[{"x": 1}],
+        reuse_cache=True,
+    )
+    combination = draft.CombinationMaterial(
+        {"tracks": [], "materials": {"videos": []}},
+        name="复合片段1",
+        duration=10_000_000,
+        width=1080,
+        height=1920,
+        matting=matting,
+        reuse_matting_cache=True,
+    )
+
+    assert (
+        combination.export_video_json()["matting"]["path"]
+        == "##_draftpath_placeholder_##/matting/cache"
+    )


### PR DESCRIPTION
## Summary
- add native draft JSON support for smart portrait matting on video materials
- add combination material support so smart matting can be applied to compound clips
- require explicit `reuse_cache=True` / `reuse_matting_cache=True` before preserving Jianying-generated matting cache fields
- merge the latest upstream `main` updates before this fix

## Root cause
Jianying matting cache fields such as `path`, `interactiveTime`, `strokes`, and quick brush flags can describe a previously generated person mask. Carrying them into a newly generated material or compound clip can make Jianying reuse a mask from another video, producing an incorrect silhouette over the current person.

## Validation
- `uv run --with pytest --with . pytest -q`
- `uv run --with flake8 --with . flake8 pyJianYingDraft/local_materials.py pyJianYingDraft/video_segment.py tests/test_combination_material.py`
- `git diff --cached --check`