### PR TITLE
Fix: 适配剪映 6.0+ 草稿文件名（draft_info.json），新增素材内联，修复 Python 3.14 兼容

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 # 功能清单
 
 > 🧪 目前处在的`0.3.0`版本经历了大规模更新，若有相关功能问题欢迎提出issue
+>
+> 📌 本仓库已针对**剪映 11.4.0（macOS）**实测校准：草稿主文件名改为 `draft_info.json`（6.0+ 不再读取 `draft_content.json`，放旧文件名会提示“草稿内容已损坏”）；新增 `script.save(inline_materials=True)`，把素材复制进草稿文件夹，规避 macOS 对桌面/文档/下载目录的访问限制。
 
 ### 视频与图片
 | 功能名称 | 5.9 支持状态 | 新版剪映支持状态 |
@@ -19,7 +21,7 @@
 | 本地视频/图片素材与[时间控制](#素材截取与整体变速) | ✅ | 10.8 ✅ |
 | [视频整体调节](#视频整体调节) | ✅ | 10.8 ✅ |
 | [视频关键帧](#关键帧) | ✅ | 10.8 ✅ |
-| [视频蒙版](#蒙版) | ✅ | 10.8 ❌<br>预计在`0.3.1`中修复 |
+| [视频蒙版](#蒙版) | ✅ | 11.4.0 ❌<br>写入的是 `materials.masks`，而新版键名为 `common_mask`，蒙版被静默丢弃 |
 | [视频色度抠图](#色度抠图) | ✅ | 10.8 ✅ |
 | 视频背景填充[(示例代码)](demo.py) | ✅ | 10.8 ✅ |
 | [视频混合模式](#视频混合模式) | ✅ | 10.8 ✅ |
@@ -74,11 +76,11 @@
 
 
 ### 模板模式
-> ⚠️ 新版剪映中的 `draft_content.json` 往往不是可直接读取的明文 JSON；因此“加载模板”相关能力在新版剪映上通常需要通过 `DraftFolder(..., fallback_loader=...)` 接入额外读取器，详情请参见[此处](https://github.com/GuanYixuan/pyJianYingDraft/releases)
+> ⚠️ 新版剪映的草稿主文件是 `draft_info.json`（6.0 起改名），且内容通常为密文；因此“加载模板”相关能力在新版剪映上通常需要通过 `DraftFolder(..., fallback_loader=...)` 接入额外读取器，详情请参见[此处](https://github.com/GuanYixuan/pyJianYingDraft/releases)
 
 | 功能名称 | 5.9 支持状态 | 新版剪映支持状态 |
 |---|---|---|
-| [加载](#加载模板) `draft_content.json` 文件作为模板 | ✅ | 10.8 🟡<br>需 `fallback_loader` |
+| [加载](#加载模板)草稿主文件作为模板 | ✅ | 11.4.0 🟡<br>需 `fallback_loader` |
 | [替换音视频片段的素材](#根据名称替换素材) | ✅ | 10.8 🟡<br>依赖模板可读 |
 | [修改文本片段的文本内容](#替换文本片段的内容) | ✅ | 10.8 🟡<br>依赖模板可读 |
 | [将模板草稿中的音视频/文本轨道整体导入到另一草稿中](#导入模板草稿中的轨道) | ✅ | 10.8 🟡<br>依赖模板可读 |
@@ -412,7 +414,7 @@ script.add_segment(seg2, "2")
 script.add_segment(seg3, "3")
 
 # 保存草稿
-script.dump("*你的草稿工程文件夹*/draft_content.json")
+script.dump("*你的草稿工程文件夹*/draft_info.json")
 ```
 
 #### 多轨道操作
@@ -486,7 +488,7 @@ video_segment.add_keyframe(KeyframeProperty.alpha, video_segment.duration, 0.0) 
 script.add_segment(video_segment)
 
 # 保存草稿
-script.dump("*你的草稿工程文件夹*/draft_content.json")
+script.dump("*你的草稿工程文件夹*/draft_info.json")
 ```
 
 除了`alpha`外，`KeyframeProperty`中还有平移、旋转、缩放、音量、饱和度等属性，它们都可以设置关键帧。

--- a/pyJianYingDraft/draft_folder.py
+++ b/pyJianYingDraft/draft_folder.py
@@ -9,6 +9,16 @@ from . import assets
 from .draft_content_loader import FallbackLoader
 from .script_file import ScriptFile
 
+DRAFT_FILE_NAME = "draft_info.json"
+"""草稿主文件名
+
+剪映 6.0 及以上版本读取此文件, 已在 11.4.0 上实测确认. 旧文件名`draft_content.json`
+仅被"草稿包导入"流程识别(该流程会将其重命名), 直接放入草稿文件夹会被判定为"草稿内容已损坏".
+"""
+
+LEGACY_DRAFT_FILE_NAME = "draft_content.json"
+"""旧版(剪映 5.9 及以下)的草稿主文件名, 仅用于读取兼容"""
+
 class DraftFolder:
     """管理一个文件夹及其内的一系列草稿"""
 
@@ -26,7 +36,8 @@ class DraftFolder:
 
         Args:
             folder_path (`str`): 包含若干草稿的文件夹, 一般取剪映保存草稿的位置即可
-            fallback_loader (`Callable`, optional): 当`draft_content.json`无法按明文 JSON 读取时使用的后备读取器.
+            fallback_loader (`Callable`, optional): 当草稿主文件无法按明文 JSON 读取时使用的后备读取器.
+                剪映 6.0 及以上版本保存的草稿是密文, 读取它们需要提供本参数.
                 其输入为文件原始字节串, 返回值仅支持 JSON 字符串或字典.
 
         Raises:
@@ -98,9 +109,27 @@ class DraftFolder:
 
         # 创建草稿文件
         script_file = ScriptFile(width, height, fps, maintrack_adsorb)
-        script_file.save_path = os.path.join(draft_path, "draft_content.json")
+        script_file.save_path = os.path.join(draft_path, DRAFT_FILE_NAME)
 
         return script_file
+
+    @staticmethod
+    def _draft_file_path(draft_path: str) -> str:
+        """草稿主文件的路径, 优先新版文件名, 回退旧版以兼容 5.9 及以下产出的草稿
+
+        Args:
+            draft_path (`str`): 草稿文件夹路径
+        """
+        new_path = os.path.join(draft_path, DRAFT_FILE_NAME)
+        if os.path.exists(new_path):
+            return new_path
+
+        legacy_path = os.path.join(draft_path, LEGACY_DRAFT_FILE_NAME)
+        if os.path.exists(legacy_path):
+            return legacy_path
+
+        # 两者均不存在时指向新版文件名, 使报错信息落在当前应有的路径上
+        return new_path
 
     def inspect_material(self, draft_name: str) -> None:
         """输出指定名称草稿中的贴纸素材元数据
@@ -137,7 +166,7 @@ class DraftFolder:
             raise FileNotFoundError(f"草稿文件夹 {draft_name} 不存在")
 
         return ScriptFile._load_template(
-            os.path.join(draft_path, "draft_content.json"),
+            self._draft_file_path(draft_path),
             fallback_loader=self.fallback_loader,
         )
 

--- a/pyJianYingDraft/script_file.py
+++ b/pyJianYingDraft/script_file.py
@@ -1,7 +1,9 @@
 import json
+import os
+import shutil
 import uuid
 from copy import deepcopy
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set
 
 from . import assets
 from . import util
@@ -12,6 +14,9 @@ from .draft_content_loader import FallbackLoader, load_draft_content
 from .script_material import ScriptMaterial
 from .template_mode import ImportedTrack, import_track
 from .track import BaseTrack, Track
+
+MATERIALS_DIR_NAME = "materials"
+"""草稿文件夹内存放内联素材的子目录名"""
 
 
 class ScriptFile(_ScriptFileTrackOps, _ScriptFileSegmentOps, _ScriptFileTemplateOps):
@@ -139,12 +144,71 @@ class ScriptFile(_ScriptFileTrackOps, _ScriptFileSegmentOps, _ScriptFileTemplate
         with open(file_path, "w", encoding="utf-8") as f:
             f.write(self.dumps())
 
-    def save(self) -> None:
+    @staticmethod
+    def _unique_material_name(name: str, used_names: Set[str]) -> str:
+        """避开`used_names`中已占用的文件名, 必要时追加序号"""
+        if name not in used_names:
+            return name
+
+        stem, suffix = os.path.splitext(name)
+        index = 1
+        while f"{stem}_{index}{suffix}" in used_names:
+            index += 1
+        return f"{stem}_{index}{suffix}"
+
+    def _inline_materials(self, target_dir: str) -> None:
+        """将本地音视频素材复制到`target_dir`并改写素材路径
+
+        剪映默认无权访问 macOS 的桌面/文档/下载目录, 引用这些位置的素材会在打开草稿时
+        提示"暂无访问权限"(草稿本身仍能正常解析). 把素材放进草稿文件夹内可绕开该限制,
+        也使草稿连同素材可以整体拷贝到另一台机器.
+
+        仅处理本对象创建的本地素材; 模板模式下导入的素材路径由剪映自行管理, 不作改动.
+
+        Args:
+            target_dir (`str`): 素材复制到的目标文件夹
+        """
+        materials = [*self.materials.videos, *self.materials.audios]
+        if not materials:
+            return
+
+        os.makedirs(target_dir, exist_ok=True)
+        copied: Dict[str, str] = {}  # 素材源路径 -> 复制后的路径
+        used_names: Set[str] = set()
+
+        for material in materials:
+            source = os.path.abspath(material.path) if material.path else ""
+            if not source or not os.path.exists(source):
+                continue  # 素材缺失交由剪映的"链接媒体"流程处理, 此处不中断保存
+
+            # 同一素材被多个片段引用时只复制一次
+            if source in copied:
+                material.path = copied[source]
+                continue
+
+            name = self._unique_material_name(os.path.basename(source), used_names)
+            used_names.add(name)
+            target = os.path.join(target_dir, name)
+            if source != os.path.abspath(target):
+                shutil.copy2(source, target)
+
+            copied[source] = target
+            material.path = target
+
+    def save(self, *, inline_materials: bool = False) -> None:
         """保存草稿文件至打开时的路径
+
+        Args:
+            inline_materials (`bool`, optional): 是否将本地素材复制进草稿文件夹的
+                `materials`子目录并改写素材路径. 默认为否.
 
         Raises:
             `ValueError`: 没有设置保存路径
         """
         if self.save_path is None:
             raise ValueError("没有设置保存路径, 可能不在模板模式下")
+
+        if inline_materials:
+            self._inline_materials(os.path.join(os.path.dirname(self.save_path), MATERIALS_DIR_NAME))
+
         self.dump(self.save_path)

--- a/pyJianYingDraft/util.py
+++ b/pyJianYingDraft/util.py
@@ -28,6 +28,16 @@ def provide_ctor_defaults(cls: Type) -> Dict[str, Any]:
 
     return provided_defaults
 
+def _own_annotations(cls: Type) -> Dict[str, Any]:
+    """获取类自身声明的注解，不含继承而来的部分
+
+    Python 3.14 起类注解改为惰性求值(PEP 649)，`cls.__dict__['__annotations__']`
+    不再总是存在，需经`inspect.get_annotations`取用。
+    """
+    if hasattr(inspect, 'get_annotations'):  # Python 3.10+
+        return inspect.get_annotations(cls)
+    return cls.__dict__.get('__annotations__', {})
+
 def assign_attr_with_json(obj: object, attrs: List[str], json_data: Dict[str, Any]):
     """根据json数据赋值给指定的对象属性
 
@@ -35,8 +45,7 @@ def assign_attr_with_json(obj: object, attrs: List[str], json_data: Dict[str, An
     """
     type_hints: Dict[str, Type] = {}
     for cls in obj.__class__.__mro__:
-        if '__annotations__' in cls.__dict__:
-            type_hints.update(cls.__annotations__)
+        type_hints.update(_own_annotations(cls))
 
     for attr in attrs:
         if hasattr(type_hints[attr], 'import_json'):

--- a/tests/test_draft_info_output.py
+++ b/tests/test_draft_info_output.py
@@ -1,0 +1,41 @@
+"""Draft output compatibility with JianYing 6.0+ (verified against 11.4.0).
+
+JianYing 6.0+ reads `draft_info.json`; `draft_content.json` is only recognised
+by the draft-package import flow, which renames it. A draft dropped into the
+draft folder under the legacy name is reported as corrupted.
+"""
+
+from __future__ import annotations
+
+import pyJianYingDraft as draft
+
+
+def test_create_draft_saves_as_draft_info_json(tmp_path):
+    folder = draft.DraftFolder(str(tmp_path))
+    script = folder.create_draft("new_draft", 1920, 1080)
+    script.save()
+
+    assert (tmp_path / "new_draft" / "draft_info.json").exists()
+
+
+def test_load_template_reads_draft_info_json(tmp_path):
+    folder = draft.DraftFolder(str(tmp_path))
+    folder.create_draft("tpl", 1920, 1080).save()
+
+    loaded = folder.load_template("tpl")
+
+    assert loaded.width == 1920
+    assert loaded.height == 1080
+
+
+def test_load_template_falls_back_to_legacy_file_name(tmp_path):
+    folder = draft.DraftFolder(str(tmp_path))
+    folder.create_draft("legacy", 1920, 1080).save()
+
+    # A draft produced by JianYing <= 5.9 only has the legacy file name.
+    draft_dir = tmp_path / "legacy"
+    (draft_dir / "draft_info.json").rename(draft_dir / "draft_content.json")
+
+    loaded = folder.load_template("legacy")
+
+    assert loaded.width == 1920

--- a/tests/test_draft_info_output.py
+++ b/tests/test_draft_info_output.py
@@ -7,7 +7,11 @@ draft folder under the legacy name is reported as corrupted.
 
 from __future__ import annotations
 
+import json
+
 import pyJianYingDraft as draft
+
+from tests.helpers import fake_audio_material, fake_video_material
 
 
 def test_create_draft_saves_as_draft_info_json(tmp_path):
@@ -39,3 +43,43 @@ def test_load_template_falls_back_to_legacy_file_name(tmp_path):
     loaded = folder.load_template("legacy")
 
     assert loaded.width == 1920
+
+
+def test_save_inline_materials_copies_files_into_draft_folder(tmp_path):
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "video.mp4").write_bytes(b"fake-video")
+    (outside / "audio.mp3").write_bytes(b"fake-audio")
+
+    folder = draft.DraftFolder(str(tmp_path))
+    script = folder.create_draft("inlined", 1920, 1080)
+    script.materials.videos.append(fake_video_material(path=str(outside / "video.mp4")))
+    script.materials.audios.append(fake_audio_material(path=str(outside / "audio.mp3")))
+
+    script.save(inline_materials=True)
+
+    materials_dir = tmp_path / "inlined" / "materials"
+    assert (materials_dir / "video.mp4").exists()
+    assert (materials_dir / "audio.mp3").exists()
+
+    content = json.loads((tmp_path / "inlined" / "draft_info.json").read_text(encoding="utf-8"))
+    exported = [item["path"] for item in content["materials"]["videos"]]
+    exported += [item["path"] for item in content["materials"]["audios"]]
+    assert exported, "expected materials in the exported draft"
+    assert all(path.startswith(str(materials_dir)) for path in exported)
+
+
+def test_save_without_inline_materials_keeps_original_paths(tmp_path):
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "video.mp4").write_bytes(b"fake-video")
+
+    folder = draft.DraftFolder(str(tmp_path))
+    script = folder.create_draft("plain", 1920, 1080)
+    script.materials.videos.append(fake_video_material(path=str(outside / "video.mp4")))
+
+    script.save()
+
+    assert not (tmp_path / "plain" / "materials").exists()
+    content = json.loads((tmp_path / "plain" / "draft_info.json").read_text(encoding="utf-8"))
+    assert content["materials"]["videos"][0]["path"] == str(outside / "video.mp4")

--- a/tests/test_template_loading.py
+++ b/tests/test_template_loading.py
@@ -12,7 +12,7 @@ def _create_template_draft(tmp_path: Path, draft_name: str) -> Path:
     folder = draft.DraftFolder(str(tmp_path))
     script = folder.create_draft(draft_name, 1920, 1080)
     script.save()
-    return tmp_path / draft_name / "draft_content.json"
+    return tmp_path / draft_name / "draft_info.json"
 
 
 def test_load_template_raises_stable_error_for_non_plain_content_without_fallback_loader(tmp_path):
@@ -69,8 +69,8 @@ def test_duplicate_as_template_reuses_fallback_loader(tmp_path):
     folder = draft.DraftFolder(str(tmp_path), fallback_loader=lambda _: plain_content)
     script = folder.duplicate_as_template("custom_format_template", "copied_template")
 
-    assert script.save_path.endswith("copied_template\\draft_content.json")
-    assert (tmp_path / "copied_template" / "draft_content.json").exists()
+    assert Path(script.save_path) == tmp_path / "copied_template" / "draft_info.json"
+    assert (tmp_path / "copied_template" / "draft_info.json").exists()
 
 
 def test_load_template_normalizes_sparse_template_content(tmp_path):

--- a/tests/test_track_insert_api.py
+++ b/tests/test_track_insert_api.py
@@ -11,7 +11,7 @@ def _load_template_script(tmp_path: Path, draft_name: str, tracks):
     script = folder.create_draft(draft_name, 1920, 1080)
     script.save()
 
-    draft_content_path = tmp_path / draft_name / "draft_content.json"
+    draft_content_path = tmp_path / draft_name / "draft_info.json"
     draft_content_path.write_bytes(b"custom payload")
 
     folder = draft.DraftFolder(


### PR DESCRIPTION
在剪映专业版 **11.4.0 (macOS)** 上实测校准。四个独立改动已拆为四个 commit，可分别 review 或 cherry-pick。

## 1. 草稿主文件名：`draft_content.json` → `draft_info.json`

这是当前版本在新版剪映上**不可用**的根本原因。

剪映 6.0 起草稿主文件更名为 `draft_info.json`。旧文件名仅在"草稿包导入"流程中被识别并重命名——客户端二进制中存在日志字符串：

```
[draft_package_import] rename draft_content.json to draft_info.json
```

直接以旧文件名放入草稿文件夹的草稿，`root_meta_info.json` 会将其登记为 `draft_info.json`，而磁盘上并无该文件，于是提示**"草稿内容已损坏"**。

改为写入 `draft_info.json` 后，生成的草稿可直接打开并正常编辑。`load_template` 优先读取新文件名、回退旧文件名，以兼容 5.9 及以下产出的草稿。

> 顺带一提：**内容明文即可，无需实现加密**。引擎侧有 `DraftIO::getUriCipherTypeStatically` 探测明文/密文，`createPlain` 处理明文；剪映打开明文草稿后会自动升级为密文格式并补齐 `Timelines/`、封面等结构。也就是说 README 中"新版剪映加密"影响的是**读取模板**，**生成**一直可行，只差文件名这一处。

## 2. 新增 `ScriptFile.save(inline_materials=True)`

草稿中素材路径为绝对路径。macOS 上若素材位于桌面/文档/下载目录，剪映因 TCC 权限限制无法读取，会弹出"链接媒体"并提示"暂无访问权限"（草稿本身解析正常）。

该选项将本地音视频素材复制进草稿文件夹的 `materials` 子目录并改写路径，同时使草稿连同素材可整体迁移。同一素材多次引用只复制一次，重名自动追加序号，素材缺失不中断保存。

默认为 `False`，不改变现有行为。

## 3. Python 3.14 兼容（PEP 649）

3.14 起类注解改为惰性求值，`cls.__dict__['__annotations__']` 不再总是存在，`assign_attr_with_json` 抛 `KeyError`，导致**模板模式的全部入口在 3.14 下不可用**。改用 `inspect.get_annotations`（3.10+），语义与原实现一致。

## 4. README 校准

- 修正两处示例的保存路径（按原文照做会直接得到"草稿内容已损坏"）
- 视频蒙版状态更新为 11.4.0 实测结果及原因（见下）

## 附：视频蒙版失效的根因

README 中标注"预计在 `0.3.1` 中修复"。本 PR **未修复**，但定位了根因，供参考：

当前实现将蒙版写入 `materials.masks`，而 **11.4.0 的 `materials` 共 55 个键中并无 `masks`，只有 `common_mask`**（对应引擎类 `lvve::MaterialCommonMask`）。客户端二进制中 `"masks"` 出现 **0** 次，`common_mask` 22 次、`MaterialCommonMask` 218 次。片段侧另有：

```cpp
SegmentVideo::set_video_mask(vector<shared_ptr<MaterialCommonMask>> const&)
SegmentVideo::set_enable_video_mask(bool const&)
```

所以蒙版数据是被**静默丢弃**的——草稿一切正常，只有蒙版无声消失。

尝试过换键名、补字段、增加 `enable_video_mask` 开关并配合三种引用形式，均未生效；`MaterialCommonMask` 的 20 个字段中 `category` / `panel` / `text_config` / `track_segment` / `contour_path` 的取值无从推断，遂止于此。若有剪映自身写出的明文样例，应当可以直接对齐。

另：将两边模板的 `materials` 键做全量对比，**除 `masks` 外无其他错配**。

## 验证

- `pytest`：**Python 3.12 与 3.14 均 49 passed**（改动前 3.12 为 1 failed、3.14 为 12 failed）
- 新增 `tests/test_draft_info_output.py`，覆盖文件名与素材内联
- 顺带修正 `test_duplicate_as_template_reuses_fallback_loader` 中硬编码的 Windows 路径分隔符（该断言在非 Windows 平台恒失败）
- 在剪映 11.4.0 上人工验证：多轨道、变速、关键帧、色度抠图、混合模式、背景填充、片段/独立轨道的特效与滤镜、转场、文本样式与描边背景、气泡花字、文本动画、自动换行、srt 字幕、音频淡入淡出与音效——**除蒙版外均正常生效**

🤖 Generated with [Claude Code](https://claude.com/claude-code)